### PR TITLE
Style changes to correspond with inserting GeoJSON below road-label

### DIFF
--- a/map box style json/style.json
+++ b/map box style json/style.json
@@ -2864,7 +2864,7 @@
                             "secondary",
                             "tertiary"
                         ],
-                        10,
+                        14,
                         [
                             "motorway_link",
                             "trunk_link",
@@ -2874,8 +2874,8 @@
                             "street",
                             "street_limited"
                         ],
-                        9,
-                        6.5
+                        12,
+                        10
                     ],
                     18,
                     [
@@ -2899,7 +2899,7 @@
                             "street_limited"
                         ],
                         14,
-                        13
+                        14
                     ]
                 ],
                 "text-max-angle": 30,
@@ -2909,20 +2909,7 @@
                 "text-rotation-alignment": "map",
                 "text-pitch-alignment": "viewport",
                 "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
-                "text-letter-spacing": 0.01,
-                "text-offset": [
-                    "interpolate",
-                    ["linear"],
-                    ["zoom"],
-                    11,
-                    ["literal", [0, -0.5]],
-                    13,
-                    ["literal", [0, -1]],
-                    17,
-                    ["literal", [0, -1.5]],
-                    22,
-                    ["literal", [0, -1.7]]
-                ]
+                "text-letter-spacing": 0.01
             },
             "paint": {
                 "text-color": "hsl(185, 3%, 47%)",


### PR DESCRIPTION
Below style changes do the following to the `road-label`s on a Mapbox Map:
- Increase the font sizes
- Remove all y-offsets

When updating both the iOS and Android apps to add the bikestreets GeoJSON layer below the road-label layer, the previous fix of simply offsetting the label was no longer needed. 

Trello card: https://trello.com/c/22xuZFS9/107-street-names-should-be-above-route-lines