### PR TITLE
Road labels larger 010720

### DIFF
--- a/map box style json/style.json
+++ b/map box style json/style.json
@@ -2915,7 +2915,7 @@
                 "text-color": "hsl(185, 3%, 47%)",
                 "text-halo-color": "hsl(185, 1%, 100%)",
                 "text-halo-width": 1,
-                "text-halo-blur": 1
+                "text-halo-blur": 0
             }
         },
         {

--- a/map box style json/style.json
+++ b/map box style json/style.json
@@ -2864,7 +2864,7 @@
                             "secondary",
                             "tertiary"
                         ],
-                        14,
+                        18,
                         [
                             "motorway_link",
                             "trunk_link",
@@ -2874,8 +2874,8 @@
                             "street",
                             "street_limited"
                         ],
-                        12,
-                        10
+                        16,
+                        14
                     ],
                     18,
                     [
@@ -2888,7 +2888,7 @@
                             "secondary",
                             "tertiary"
                         ],
-                        16,
+                        26,
                         [
                             "motorway_link",
                             "trunk_link",
@@ -2898,8 +2898,8 @@
                             "street",
                             "street_limited"
                         ],
-                        14,
-                        14
+                        22,
+                        18
                     ]
                 ],
                 "text-max-angle": 30,

--- a/map box style json/style.json
+++ b/map box style json/style.json
@@ -2914,7 +2914,7 @@
             "paint": {
                 "text-color": "hsl(185, 3%, 47%)",
                 "text-halo-color": "hsl(185, 1%, 100%)",
-                "text-halo-width": 1,
+                "text-halo-width": 3,
                 "text-halo-blur": 0
             }
         },


### PR DESCRIPTION
In order to increase readability of the map, font sizes of the road labels are increased and the blur behind the road label "halo" is made opaque by removing the blur entirely.

Trello Card: https://trello.com/c/ewPt2oXb/136-increase-street-name-readibility